### PR TITLE
bugfix transient null values received for LogProbs

### DIFF
--- a/OpenAI_API/Completions/CompletionResult.cs
+++ b/OpenAI_API/Completions/CompletionResult.cs
@@ -116,7 +116,7 @@ namespace OpenAI_API
 		public List<string> Tokens { get; set; }
 
 		[JsonProperty("token_logprobs")]
-		public List<double> TokenLogprobs { get; set; }
+		public List<double?> TokenLogprobs { get; set; }
 
 		[JsonProperty("top_logprobs")]
 		public IList<IDictionary<string, double>> TopLogprobs { get; set; }

--- a/OpenAI_Tests/CompletionEndpointTests.cs
+++ b/OpenAI_Tests/CompletionEndpointTests.cs
@@ -1,13 +1,15 @@
 ﻿using NUnit.Framework;
 using OpenAI_API;
 using System;
-using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace OpenAI_Tests
 {
 	public class CompletionEndpointTests
 	{
+		private OpenAIAPI GetApi => new OpenAIAPI(engine: Engine.Ada);
+
 		[SetUp]
 		public void Setup()
 		{
@@ -26,6 +28,25 @@ namespace OpenAI_Tests
 			Assert.NotNull(results.Completions);
 			Assert.NotZero(results.Completions.Count);
 			Assert.That(results.Completions.Any(c => c.Text.Trim().ToLower().StartsWith("nine")));
+		}
+
+		[TestCase("eight")]
+		[TestCase("nine")]
+		public async Task CreateCompletionAsync_ShouldStopOnStopSequence(string stopSeq)
+		{
+			var api = GetApi;
+
+			var completionReq = new CompletionRequest
+			{
+				Prompt = "three four five",
+				Temperature = 0,
+				MaxTokens = 5,
+				Echo = true,
+				StopSequence = stopSeq
+			};
+
+			var results = await api.Completions.CreateCompletionsAsync(completionReq);
+			Assert.NotZero(results.Completions.Count);
 		}
 
 		// TODO: More tests needed but this covers basic functionality at least


### PR DESCRIPTION
[Logprobs results in Newtonsoft SerializationException](https://github.com/OkGoDoIt/OpenAI-API-dotnet/issues/5) happens from time to time (not clear under what conditions). An easy fix is to allow null logprops.

I have also added an extra test (used to fail with the exception mentioned in the issue).