### PR TITLE
Updates Newtonsoft (thanks dependabot) and adds Da Vinci 2 to the engines that are accessible

### DIFF
--- a/OpenAI_API/Engine/Engine.cs
+++ b/OpenAI_API/Engine/Engine.cs
@@ -95,14 +95,19 @@ namespace OpenAI_API
 		/// </summary>
 		public static Engine Curie => new Engine("curie") { Owner = "openai", Ready = true };
 		/// <summary>
-		/// The most powerful, largest engine available, although the speed is quite slow.
+		/// The (former) most powerful, largest engine available, although the speed is quite slow.
 		/// </summary>
 		public static Engine Davinci => new Engine("davinci") { Owner = "openai", Ready = true };
 
 		/// <summary>
+        /// The current most powerful, largest engine available. 
+        /// </summary>
+		public static Engine Davinci_2 => new Engine("text-davinci-002") { Owner = "openai", Ready = true };
+
+		/// <summary>
 		/// The default Engine to use in the case no other is specified.  Defaults to <see cref="Davinci"/>
 		/// </summary>
-		public static Engine Default => Davinci;
+		public static Engine Default => Davinci_2;
 
 		/// <summary>
 		/// Gets more details about this Engine from the API, specifically properties such as <see cref="Owner"/> and <see cref="Ready"/>

--- a/OpenAI_API/OpenAI_API.csproj
+++ b/OpenAI_API/OpenAI_API.csproj
@@ -25,7 +25,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
-		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Your one-stop shop if you are looking to use this and want to access Da Vinci 2.

I'm just sharing the changes I needed to get it to work since the original repository does not seem likely to get any updates any time soon.