### PR TITLE
#68 OpenApi Endpoint Properties & Missing ChatEndpoint

### DIFF
--- a/OpenAI_API/APIAuthentication.cs
+++ b/OpenAI_API/APIAuthentication.cs
@@ -9,7 +9,7 @@ namespace OpenAI_API
 	/// <summary>
 	/// Represents authentication to the OpenAPI API endpoint
 	/// </summary>
-	public class APIAuthentication
+	public class APIAuthentication : IAPIAuthentication
 	{
 		/// <summary>
 		/// The API key, required to access the API endpoint.

--- a/OpenAI_API/IAPIAuthentication.cs
+++ b/OpenAI_API/IAPIAuthentication.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+
+namespace OpenAI_API
+{
+    /// <summary>
+    /// Represents authentication to the OpenAPI API endpoint
+    /// </summary>
+    public interface IAPIAuthentication
+    {
+        /// <summary>
+        /// The API key, required to access the API endpoint.
+        /// </summary>
+        string ApiKey { get; set; }
+
+        /// <summary>
+        /// The Organization ID to count API requests against.  This can be found at https://beta.openai.com/account/org-settings.
+        /// </summary>
+        string OpenAIOrganization { get; set; }
+
+        /// <summary>
+        /// Tests the api key against the OpenAI API, to ensure it is valid.  This hits the models endpoint so should not be charged for usage.
+        /// </summary>
+        /// <returns><see langword="true"/> if the api key is valid, or <see langword="false"/> if empty or not accepted by the OpenAI API.</returns>
+        Task<bool> ValidateAPIKey();
+    }
+}

--- a/OpenAI_API/IOpenAIAPI.cs
+++ b/OpenAI_API/IOpenAIAPI.cs
@@ -1,3 +1,4 @@
+using OpenAI_API.Chat;
 using OpenAI_API.Completions;
 using OpenAI_API.Embedding;
 using OpenAI_API.Files;
@@ -36,6 +37,11 @@ namespace OpenAI_API
         /// The API lets you transform text into a vector (list) of floating point numbers. The distance between two vectors measures their relatedness. Small distances suggest high relatedness and large distances suggest low relatedness.
         /// </summary>
         IEmbeddingEndpoint Embeddings { get; }
+        
+        /// <summary>
+        /// Text generation in the form of chat messages. This interacts with the ChatGPT API.
+        /// </summary>
+        IChatEndpoint Chat { get; }
 
         /// <summary>
         /// The API endpoint for querying available Engines/models

--- a/OpenAI_API/IOpenAIAPI.cs
+++ b/OpenAI_API/IOpenAIAPI.cs
@@ -25,26 +25,26 @@ namespace OpenAI_API
         /// <summary>
         /// The API authentication information to use for API calls
         /// </summary>
-        APIAuthentication Auth { get; set; }
+        IAPIAuthentication Auth { get; set; }
 
         /// <summary>
         /// Text generation is the core function of the API. You give the API a prompt, and it generates a completion. The way you “program” the API to do a task is by simply describing the task in plain english or providing a few written examples. This simple approach works for a wide range of use cases, including summarization, translation, grammar correction, question answering, chatbots, composing emails, and much more (see the prompt library for inspiration).
         /// </summary>
-        CompletionEndpoint Completions { get; }
+        ICompletionEndpoint Completions { get; }
 
         /// <summary>
         /// The API lets you transform text into a vector (list) of floating point numbers. The distance between two vectors measures their relatedness. Small distances suggest high relatedness and large distances suggest low relatedness.
         /// </summary>
-        EmbeddingEndpoint Embeddings { get; }
+        IEmbeddingEndpoint Embeddings { get; }
 
         /// <summary>
         /// The API endpoint for querying available Engines/models
         /// </summary>
-        ModelsEndpoint Models { get; }
+        IModelsEndpoint Models { get; }
 
         /// <summary>
         /// The API lets you do operations with files. You can upload, delete or retrieve files. Files can be used for fine-tuning, search, etc.
         /// </summary>
-        FilesEndpoint Files { get; }
+        IFilesEndpoint Files { get; }
     }
 }

--- a/OpenAI_API/OpenAIAPI.cs
+++ b/OpenAI_API/OpenAIAPI.cs
@@ -29,7 +29,7 @@ namespace OpenAI_API
 		/// <summary>
 		/// The API authentication information to use for API calls
 		/// </summary>
-		public APIAuthentication Auth { get; set; }
+		public IAPIAuthentication Auth { get; set; }
 
 		/// <summary>
 		/// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
@@ -65,37 +65,37 @@ namespace OpenAI_API
 		/// <summary>
 		/// Text generation is the core function of the API. You give the API a prompt, and it generates a completion. The way you “program” the API to do a task is by simply describing the task in plain english or providing a few written examples. This simple approach works for a wide range of use cases, including summarization, translation, grammar correction, question answering, chatbots, composing emails, and much more (see the prompt library for inspiration).
 		/// </summary>
-		public CompletionEndpoint Completions { get; }
+		public ICompletionEndpoint Completions { get; }
 
 		/// <summary>
 		/// The API lets you transform text into a vector (list) of floating point numbers. The distance between two vectors measures their relatedness. Small distances suggest high relatedness and large distances suggest low relatedness.
 		/// </summary>
-		public EmbeddingEndpoint Embeddings { get; }
+		public IEmbeddingEndpoint Embeddings { get; }
 
 		/// <summary>
 		/// Text generation in the form of chat messages. This interacts with the ChatGPT API.
 		/// </summary>
-		public ChatEndpoint Chat { get; }
+		public IChatEndpoint Chat { get; }
 
 		/// <summary>
 		/// Classify text against the OpenAI Content Policy.
 		/// </summary>
-		public ModerationEndpoint Moderation { get; }
+		public IModerationEndpoint Moderation { get; }
 
 		/// <summary>
 		/// The API endpoint for querying available Engines/models
 		/// </summary>
-		public ModelsEndpoint Models { get; }
+		public IModelsEndpoint Models { get; }
 
 		/// <summary>
 		/// The API lets you do operations with files. You can upload, delete or retrieve files. Files can be used for fine-tuning, search, etc.
 		/// </summary>
-		public FilesEndpoint Files { get; }
+		public IFilesEndpoint Files { get; }
 
 		/// <summary>
 		/// The API lets you do operations with images. You can Given a prompt and/or an input image, the model will generate a new image.
 		/// </summary>
-		public ImageGenerationEndpoint ImageGenerations { get; }
+		public IImageGenerationEndpoint ImageGenerations { get; }
 
 	}
 }

--- a/OpenAI_Tests/AuthTests.cs
+++ b/OpenAI_Tests/AuthTests.cs
@@ -67,14 +67,14 @@ namespace OpenAI_Tests
 			OpenAI_API.APIAuthentication defaultAuth = OpenAI_API.APIAuthentication.Default;
 			OpenAI_API.APIAuthentication manualAuth = new OpenAI_API.APIAuthentication("pk-testAA");
 			OpenAI_API.OpenAIAPI api = new OpenAI_API.OpenAIAPI();
-			OpenAI_API.APIAuthentication shouldBeDefaultAuth = api.Auth;
+			OpenAI_API.IAPIAuthentication shouldBeDefaultAuth = api.Auth;
 			Assert.IsNotNull(shouldBeDefaultAuth);
 			Assert.IsNotNull(shouldBeDefaultAuth.ApiKey);
 			Assert.AreEqual(defaultAuth.ApiKey, shouldBeDefaultAuth.ApiKey);
 
 			OpenAI_API.APIAuthentication.Default = new OpenAI_API.APIAuthentication("pk-testAA");
 			api = new OpenAI_API.OpenAIAPI();
-			OpenAI_API.APIAuthentication shouldBeManualAuth = api.Auth;
+			OpenAI_API.IAPIAuthentication shouldBeManualAuth = api.Auth;
 			Assert.IsNotNull(shouldBeManualAuth);
 			Assert.IsNotNull(shouldBeManualAuth.ApiKey);
 			Assert.AreEqual(manualAuth.ApiKey, shouldBeManualAuth.ApiKey);


### PR DESCRIPTION
Here's a quick rundown of what I've done:

1. Added the missing IApiAuthentication interface that was previously absent.
1. Made some changes to the OpenAIAPI class to use interfaces instead of classes, making it more testable and easier to mock.
1. Added the IChatEndpoint Property to the IOpenAIAPI interface, which was missing before.
1. Updated the Auth test to use the newly added IAPIAuthentication interface.

I'm confident that these changes will help to enhance the overall quality and maintainability of the codebase. Please let me know if you have any questions or feedback on these changes.