### PR TITLE
Add streaming methods for Conversation class

### DIFF
--- a/OpenAI_API/Chat/Conversation.cs
+++ b/OpenAI_API/Chat/Conversation.cs
@@ -122,5 +122,52 @@ namespace OpenAI_API.Chat
 			}
 			return null;
 		}
+
+		/// <summary>
+		/// Calls the API to get a response, which is appended to the current chat's <see cref="Messages"/> as an <see cref="ChatMessageRole.Assistant"/> <see cref="ChatMessage"/>, and streams the results to the <paramref name="resultHandler"/> as they come in. <br/>
+		/// If you are on the latest C# supporting async enumerables, you may prefer the cleaner syntax of <see cref="StreamResponseEnumerableFromChatbot"/> instead.
+		///  </summary>
+		/// <param name="resultHandler">An action to be called as each new result arrives.</param>
+		public async Task StreamResponseFromChatbot(Action<string> resultHandler)
+		{
+			await foreach (string res in StreamResponseEnumerableFromChatbot())
+			{
+				resultHandler(res);
+			}
+		}
+
+		/// <summary>
+		/// Calls the API to get a response, which is appended to the current chat's <see cref="Messages"/> as an <see cref="ChatMessageRole.Assistant"/> <see cref="ChatMessage"/>, and streams the results as they come in. <br/>
+		/// If you are not using C# 8 supporting async enumerables or if you are using the .NET Framework, you may need to use <see cref="StreamResponseFromChatbot"/> instead.
+		/// </summary>
+		/// <returns>An async enumerable with each of the results as they come in.  See <see href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#asynchronous-streams"/> for more details on how to consume an async enumerable.</returns>
+		public async IAsyncEnumerable<string> StreamResponseEnumerableFromChatbot()
+		{
+			ChatRequest req = new ChatRequest(RequestParameters);
+			req.Messages = _Messages.ToList();
+
+			StringBuilder responseStringBuilder = new StringBuilder();
+			ChatMessageRole responseRole = null;
+
+			await foreach (var res in _endpoint.StreamChatEnumerableAsync(req))
+			{
+				if (res.Choices.FirstOrDefault()?.Delta is ChatMessage delta)
+				{
+					responseRole = delta.Role;
+					string deltaContent = delta.Content;
+
+					if (!string.IsNullOrEmpty(deltaContent))
+					{
+						responseStringBuilder.Append(deltaContent);
+						yield return deltaContent;
+					}
+				}
+			}
+
+			if (responseRole != null)
+			{
+				AppendMessage(responseRole, responseStringBuilder.ToString());
+			}
+		}
 	}
 }

--- a/OpenAI_API/Chat/Conversation.cs
+++ b/OpenAI_API/Chat/Conversation.cs
@@ -125,12 +125,12 @@ namespace OpenAI_API.Chat
 
 		/// <summary>
 		/// Calls the API to get a response, which is appended to the current chat's <see cref="Messages"/> as an <see cref="ChatMessageRole.Assistant"/> <see cref="ChatMessage"/>, and streams the results to the <paramref name="resultHandler"/> as they come in. <br/>
-		/// If you are on the latest C# supporting async enumerables, you may prefer the cleaner syntax of <see cref="StreamResponseEnumerableFromChatbot"/> instead.
+		/// If you are on the latest C# supporting async enumerables, you may prefer the cleaner syntax of <see cref="StreamResponseEnumerableFromChatbotAsync"/> instead.
 		///  </summary>
 		/// <param name="resultHandler">An action to be called as each new result arrives.</param>
-		public async Task StreamResponseFromChatbot(Action<string> resultHandler)
+		public async Task StreamResponseFromChatbotAsync(Action<string> resultHandler)
 		{
-			await foreach (string res in StreamResponseEnumerableFromChatbot())
+			await foreach (string res in StreamResponseEnumerableFromChatbotAsync())
 			{
 				resultHandler(res);
 			}
@@ -138,10 +138,10 @@ namespace OpenAI_API.Chat
 
 		/// <summary>
 		/// Calls the API to get a response, which is appended to the current chat's <see cref="Messages"/> as an <see cref="ChatMessageRole.Assistant"/> <see cref="ChatMessage"/>, and streams the results as they come in. <br/>
-		/// If you are not using C# 8 supporting async enumerables or if you are using the .NET Framework, you may need to use <see cref="StreamResponseFromChatbot"/> instead.
+		/// If you are not using C# 8 supporting async enumerables or if you are using the .NET Framework, you may need to use <see cref="StreamResponseFromChatbotAsync"/> instead.
 		/// </summary>
 		/// <returns>An async enumerable with each of the results as they come in.  See <see href="https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#asynchronous-streams"/> for more details on how to consume an async enumerable.</returns>
-		public async IAsyncEnumerable<string> StreamResponseEnumerableFromChatbot()
+		public async IAsyncEnumerable<string> StreamResponseEnumerableFromChatbotAsync()
 		{
 			ChatRequest req = new ChatRequest(RequestParameters);
 			req.Messages = _Messages.ToList();

--- a/README.md
+++ b/README.md
@@ -115,6 +115,32 @@ foreach (ChatMessage msg in chat.Messages)
 }
 ```
 
+#### Streaming
+
+Streaming allows you to get results are they are generated, which can help your application feel more responsive.
+
+Using the new C# 8.0 async iterators:
+```csharp
+var chat = api.Chat.CreateConversation();
+chat.AppendUserInput("How to make a hamburger?");
+
+await foreach (var res in chat.StreamResponseEnumerableFromChatbot())
+{
+	Console.Write(res);
+}
+```
+
+Or if using classic .NET framework or C# <8.0:
+```csharp
+var chat = api.Chat.CreateConversation();
+chat.AppendUserInput("How to make a hamburger?");
+
+await chat.StreamResponseFromChatbot(res =>
+{
+    Console.Write(res);
+});
+```
+
 #### Chat Endpoint Requests
 You can access full control of the Chat API by using the `OpenAIAPI.Chat.CreateChatCompletionAsync()` and related methods.
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ chat.AppendUserInput("How to make a hamburger?");
 
 await foreach (var res in chat.StreamResponseEnumerableFromChatbot())
 {
-	Console.Write(res);
+    Console.Write(res);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Using the new C# 8.0 async iterators:
 var chat = api.Chat.CreateConversation();
 chat.AppendUserInput("How to make a hamburger?");
 
-await foreach (var res in chat.StreamResponseEnumerableFromChatbot())
+await foreach (var res in chat.StreamResponseEnumerableFromChatbotAsync())
 {
     Console.Write(res);
 }
@@ -135,7 +135,7 @@ Or if using classic .NET framework or C# <8.0:
 var chat = api.Chat.CreateConversation();
 chat.AppendUserInput("How to make a hamburger?");
 
-await chat.StreamResponseFromChatbot(res =>
+await chat.StreamResponseFromChatbotAsync(res =>
 {
     Console.Write(res);
 });


### PR DESCRIPTION
Add streaming methods for `Conversation` class for convenience.

Using the new C# 8.0 async iterators:
```csharp
var chat = api.Chat.CreateConversation();
chat.AppendUserInput("How to make a hamburger?");

await foreach (var res in chat.StreamResponseEnumerableFromChatbotAsync())
{
    Console.Write(res);
}
```

Or if using classic .NET framework or C# <8.0:
```csharp
var chat = api.Chat.CreateConversationAsync();
chat.AppendUserInput("How to make a hamburger?");

await chat.StreamResponseFromChatbotAsync(res =>
{
    Console.Write(res);
});
```