### PR TITLE
Async suffix added so the intent is clear and there's no ambiguity.

### DIFF
--- a/OpenAI_API/APIAuthentication.cs
+++ b/OpenAI_API/APIAuthentication.cs
@@ -163,7 +163,7 @@ namespace OpenAI_API
 		/// Tests the api key against the OpenAI API, to ensure it is valid.  This hits the models endpoint so should not be charged for usage.
 		/// </summary>
 		/// <returns><see langword="true"/> if the api key is valid, or <see langword="false"/> if empty or not accepted by the OpenAI API.</returns>
-		public async Task<bool> ValidateAPIKey()
+		public async Task<bool> ValidateAPIKeyAsync()
 		{
 			if (string.IsNullOrEmpty(ApiKey))
 				return false;

--- a/OpenAI_API/Chat/ChatEndpoint.cs
+++ b/OpenAI_API/Chat/ChatEndpoint.cs
@@ -47,7 +47,7 @@ namespace OpenAI_API.Chat
 		/// <returns>Asynchronously returns the completion result. Look in its <see cref="ChatResult.Choices"/> property for the results.</returns>
 		public async Task<ChatResult> CreateChatCompletionAsync(ChatRequest request)
 		{
-			return await HttpPost<ChatResult>(postData: request);
+			return await HttpPostAsync<ChatResult>(postData: request);
 		}
 
 		/// <summary>
@@ -167,7 +167,7 @@ namespace OpenAI_API.Chat
 		public IAsyncEnumerable<ChatResult> StreamChatEnumerableAsync(ChatRequest request)
 		{
 			request = new ChatRequest(request) { Stream = true };
-			return HttpStreamingRequest<ChatResult>(Url, HttpMethod.Post, request);
+			return HttpStreamingRequestAsync<ChatResult>(Url, HttpMethod.Post, request);
 		}
 
 		/// <summary>

--- a/OpenAI_API/Chat/Conversation.cs
+++ b/OpenAI_API/Chat/Conversation.cs
@@ -40,7 +40,7 @@ namespace OpenAI_API.Chat
 		}
 
 		/// <summary>
-		/// After calling <see cref="GetResponseFromChatbot"/>, this contains the full response object which can contain useful metadata like token usages, <see cref="ChatChoice.FinishReason"/>, etc.  This is overwritten with every call to <see cref="GetResponseFromChatbot"/> and only contains the most recent result.
+		/// After calling <see cref="GetResponseFromChatbotAsync"/>, this contains the full response object which can contain useful metadata like token usages, <see cref="ChatChoice.FinishReason"/>, etc.  This is overwritten with every call to <see cref="GetResponseFromChatbotAsync"/> and only contains the most recent result.
 		/// </summary>
 		public ChatResult MostResentAPIResult { get; private set; }
 
@@ -106,7 +106,7 @@ namespace OpenAI_API.Chat
 		/// Calls the API to get a response, which is appended to the current chat's <see cref="Messages"/> as an <see cref="ChatMessageRole.Assistant"/> <see cref="ChatMessage"/>.
 		/// </summary>
 		/// <returns>The string of the response from the chatbot API</returns>
-		public async Task<string> GetResponseFromChatbot()
+		public async Task<string> GetResponseFromChatbotAsync()
 		{
 			ChatRequest req = new ChatRequest(RequestParameters);
 			req.Messages = _Messages.ToList();

--- a/OpenAI_API/Completions/CompletionEndpoint.cs
+++ b/OpenAI_API/Completions/CompletionEndpoint.cs
@@ -36,7 +36,7 @@ namespace OpenAI_API.Completions
 		/// <returns>Asynchronously returns the completion result.  Look in its <see cref="CompletionResult.Completions"/> property for the completions.</returns>
 		public async Task<CompletionResult> CreateCompletionAsync(CompletionRequest request)
 		{
-			return await HttpPost<CompletionResult>(postData: request);
+			return await HttpPostAsync<CompletionResult>(postData: request);
 		}
 
 		/// <summary>
@@ -153,7 +153,7 @@ namespace OpenAI_API.Completions
 		public IAsyncEnumerable<CompletionResult> StreamCompletionEnumerableAsync(CompletionRequest request)
 		{
 			request = new CompletionRequest(request) { Stream = true };
-			return HttpStreamingRequest<CompletionResult>(Url, HttpMethod.Post, request);
+			return HttpStreamingRequestAsync<CompletionResult>(Url, HttpMethod.Post, request);
 		}
 
 		/// <summary>
@@ -211,7 +211,7 @@ namespace OpenAI_API.Completions
 		/// </summary>
 		/// <param name="request">The request to send to the API.  This does not fall back to default values specified in <see cref="DefaultCompletionRequestArgs"/>.</param>
 		/// <returns>A string of the prompt followed by the best completion</returns>
-		public async Task<string> CreateAndFormatCompletion(CompletionRequest request)
+		public async Task<string> CreateAndFormatCompletionAsync(CompletionRequest request)
 		{
 			string prompt = request.Prompt;
 			var result = await CreateCompletionAsync(request);
@@ -223,7 +223,7 @@ namespace OpenAI_API.Completions
 		/// </summary>
 		/// <param name="prompt">The prompt to complete</param>
 		/// <returns>The best completion</returns>
-		public async Task<string> GetCompletion(string prompt)
+		public async Task<string> GetCompletionAsync(string prompt)
 		{
 			CompletionRequest request = new CompletionRequest(DefaultCompletionRequestArgs)
 			{

--- a/OpenAI_API/Completions/ICompletionEndpoint.cs
+++ b/OpenAI_API/Completions/ICompletionEndpoint.cs
@@ -123,13 +123,13 @@ namespace OpenAI_API.Completions
         /// </summary>
         /// <param name="request">The request to send to the API.  This does not fall back to default values specified in <see cref="DefaultCompletionRequestArgs"/>.</param>
         /// <returns>A string of the prompt followed by the best completion</returns>
-        Task<string> CreateAndFormatCompletion(CompletionRequest request);
+        Task<string> CreateAndFormatCompletionAsync(CompletionRequest request);
 
         /// <summary>
         /// Simply returns the best completion
         /// </summary>
         /// <param name="prompt">The prompt to complete</param>
         /// <returns>The best completion</returns>
-        Task<string> GetCompletion(string prompt);
+        Task<string> GetCompletionAsync(string prompt);
     }
 }

--- a/OpenAI_API/Embedding/EmbeddingEndpoint.cs
+++ b/OpenAI_API/Embedding/EmbeddingEndpoint.cs
@@ -42,7 +42,7 @@ namespace OpenAI_API.Embedding
 		/// <returns>Asynchronously returns the embedding result. Look in its <see cref="Data.Embedding"/> property of <see cref="EmbeddingResult.Data"/> to find the vector of floating point numbers</returns>
 		public async Task<EmbeddingResult> CreateEmbeddingAsync(EmbeddingRequest request)
 		{
-			return await HttpPost<EmbeddingResult>(postData: request);
+			return await HttpPostAsync<EmbeddingResult>(postData: request);
 		}
 
 		/// <summary>

--- a/OpenAI_API/EndpointBase.cs
+++ b/OpenAI_API/EndpointBase.cs
@@ -101,7 +101,7 @@ namespace OpenAI_API
 		/// <param name="streaming">(optional) If true, streams the response.  Otherwise waits for the entire response before returning.</param>
 		/// <returns>The HttpResponseMessage of the response, which is confirmed to be successful.</returns>
 		/// <exception cref="HttpRequestException">Throws an exception if a non-success HTTP response was returned</exception>
-		private async Task<HttpResponseMessage> HttpRequestRaw(string url = null, HttpMethod verb = null, object postData = null, bool streaming = false)
+		private async Task<HttpResponseMessage> HttpRequestRawAsync(string url = null, HttpMethod verb = null, object postData = null, bool streaming = false)
 		{
 			if (string.IsNullOrEmpty(url))
 				url = this.Url;
@@ -166,9 +166,9 @@ namespace OpenAI_API
 		/// <param name="url">(optional) If provided, overrides the url endpoint for this request.  If omitted, then <see cref="Url"/> will be used.</param>
 		/// <returns>The text string of the response, which is confirmed to be successful.</returns>
 		/// <exception cref="HttpRequestException">Throws an exception if a non-success HTTP response was returned</exception>
-		internal async Task<string> HttpGetContent<T>(string url = null)
+		internal async Task<string> HttpGetContentAsync<T>(string url = null)
 		{
-			var response = await HttpRequestRaw(url);
+			var response = await HttpRequestRawAsync(url);
 			return await response.Content.ReadAsStringAsync();
 		}
 
@@ -182,9 +182,9 @@ namespace OpenAI_API
 		/// <param name="postData">(optional) A json-serializable object to include in the request body.</param>
 		/// <returns>An awaitable Task with the parsed result of type <typeparamref name="T"/></returns>
 		/// <exception cref="HttpRequestException">Throws an exception if a non-success HTTP response was returned or if the result couldn't be parsed.</exception>
-		private async Task<T> HttpRequest<T>(string url = null, HttpMethod verb = null, object postData = null) where T : ApiResultBase
+		private async Task<T> HttpRequestAsync<T>(string url = null, HttpMethod verb = null, object postData = null) where T : ApiResultBase
 		{
-			var response = await HttpRequestRaw(url, verb, postData);
+			var response = await HttpRequestRawAsync(url, verb, postData);
 			string resultAsString = await response.Content.ReadAsStringAsync();
 
 			var res = JsonConvert.DeserializeObject<T>(resultAsString);
@@ -246,9 +246,9 @@ namespace OpenAI_API
 		/// <param name="url">(optional) If provided, overrides the url endpoint for this request.  If omitted, then <see cref="Url"/> will be used.</param>
 		/// <returns>An awaitable Task with the parsed result of type <typeparamref name="T"/></returns>
 		/// <exception cref="HttpRequestException">Throws an exception if a non-success HTTP response was returned or if the result couldn't be parsed.</exception>
-		internal async Task<T> HttpGet<T>(string url = null) where T : ApiResultBase
+		internal async Task<T> HttpGetAsync<T>(string url = null) where T : ApiResultBase
 		{
-			return await HttpRequest<T>(url, HttpMethod.Get);
+			return await HttpRequestAsync<T>(url, HttpMethod.Get);
 		}
 
 		/// <summary>
@@ -259,9 +259,9 @@ namespace OpenAI_API
 		/// <param name="postData">(optional) A json-serializable object to include in the request body.</param>
 		/// <returns>An awaitable Task with the parsed result of type <typeparamref name="T"/></returns>
 		/// <exception cref="HttpRequestException">Throws an exception if a non-success HTTP response was returned or if the result couldn't be parsed.</exception>
-		internal async Task<T> HttpPost<T>(string url = null, object postData = null) where T : ApiResultBase
+		internal async Task<T> HttpPostAsync<T>(string url = null, object postData = null) where T : ApiResultBase
 		{
-			return await HttpRequest<T>(url, HttpMethod.Post, postData);
+			return await HttpRequestAsync<T>(url, HttpMethod.Post, postData);
 		}
 
 		/// <summary>
@@ -272,9 +272,9 @@ namespace OpenAI_API
 		/// <param name="postData">(optional) A json-serializable object to include in the request body.</param>
 		/// <returns>An awaitable Task with the parsed result of type <typeparamref name="T"/></returns>
 		/// <exception cref="HttpRequestException">Throws an exception if a non-success HTTP response was returned or if the result couldn't be parsed.</exception>
-		internal async Task<T> HttpDelete<T>(string url = null, object postData = null) where T : ApiResultBase
+		internal async Task<T> HttpDeleteAsync<T>(string url = null, object postData = null) where T : ApiResultBase
 		{
-			return await HttpRequest<T>(url, HttpMethod.Delete, postData);
+			return await HttpRequestAsync<T>(url, HttpMethod.Delete, postData);
 		}
 
 
@@ -286,9 +286,9 @@ namespace OpenAI_API
 		/// <param name="postData">(optional) A json-serializable object to include in the request body.</param>
 		/// <returns>An awaitable Task with the parsed result of type <typeparamref name="T"/></returns>
 		/// <exception cref="HttpRequestException">Throws an exception if a non-success HTTP response was returned or if the result couldn't be parsed.</exception>
-		internal async Task<T> HttpPut<T>(string url = null, object postData = null) where T : ApiResultBase
+		internal async Task<T> HttpPutAsync<T>(string url = null, object postData = null) where T : ApiResultBase
 		{
-			return await HttpRequest<T>(url, HttpMethod.Put, postData);
+			return await HttpRequestAsync<T>(url, HttpMethod.Put, postData);
 		}
 
 
@@ -336,9 +336,9 @@ namespace OpenAI_API
 		/// <param name="postData">(optional) A json-serializable object to include in the request body.</param>
 		/// <returns>The HttpResponseMessage of the response, which is confirmed to be successful.</returns>
 		/// <exception cref="HttpRequestException">Throws an exception if a non-success HTTP response was returned</exception>
-		protected async IAsyncEnumerable<T> HttpStreamingRequest<T>(string url = null, HttpMethod verb = null, object postData = null) where T : ApiResultBase
+		protected async IAsyncEnumerable<T> HttpStreamingRequestAsync<T>(string url = null, HttpMethod verb = null, object postData = null) where T : ApiResultBase
 		{
-			var response = await HttpRequestRaw(url, verb, postData, true);
+			var response = await HttpRequestRawAsync(url, verb, postData, true);
 
 			string organization = null;
 			string requestId = null;

--- a/OpenAI_API/Files/FilesEndpoint.cs
+++ b/OpenAI_API/Files/FilesEndpoint.cs
@@ -29,7 +29,7 @@ namespace OpenAI_API.Files
 		/// <exception cref="HttpRequestException"></exception>
 		public async Task<List<File>> GetFilesAsync()
 		{
-			return (await HttpGet<FilesData>()).Data;
+			return (await HttpGetAsync<FilesData>()).Data;
 		}
 
 		/// <summary>
@@ -39,7 +39,7 @@ namespace OpenAI_API.Files
 		/// <returns></returns>
 		public async Task<File> GetFileAsync(string fileId)
 		{
-			return await HttpGet<File>($"{Url}/{fileId}");
+			return await HttpGetAsync<File>($"{Url}/{fileId}");
 		}
 
 
@@ -50,7 +50,7 @@ namespace OpenAI_API.Files
 		/// <returns></returns>
 		public async Task<string> GetFileContentAsStringAsync(string fileId)
 		{
-			return await HttpGetContent<File>($"{Url}/{fileId}/content");
+			return await HttpGetContentAsync<File>($"{Url}/{fileId}/content");
 		}
 
 		/// <summary>
@@ -60,7 +60,7 @@ namespace OpenAI_API.Files
 		/// <returns></returns>
 		public async Task<File> DeleteFileAsync(string fileId)
 		{
-			return await HttpDelete<File>($"{Url}/{fileId}");
+			return await HttpDeleteAsync<File>($"{Url}/{fileId}");
 		}
 
 
@@ -77,7 +77,7 @@ namespace OpenAI_API.Files
 				{ new ByteArrayContent(System.IO.File.ReadAllBytes(filePath)), "file", Path.GetFileName(filePath) }
 			};
 
-			return await HttpPost<File>(Url, content);
+			return await HttpPostAsync<File>(Url, content);
 		}
 
 		/// <summary>

--- a/OpenAI_API/Images/ImageGenerationEndpoint.cs
+++ b/OpenAI_API/Images/ImageGenerationEndpoint.cs
@@ -40,7 +40,7 @@ namespace OpenAI_API.Images
 		/// <returns>Asynchronously returns the image result. Look in its <see cref="Data.Url"/> </returns>
 		public async Task<ImageResult> CreateImageAsync(ImageGenerationRequest request)
 		{
-			return await HttpPost<ImageResult>(postData: request);
+			return await HttpPostAsync<ImageResult>(postData: request);
 		}
 	}
 }

--- a/OpenAI_API/Model/ModelsEndpoint.cs
+++ b/OpenAI_API/Model/ModelsEndpoint.cs
@@ -28,7 +28,7 @@ namespace OpenAI_API.Models
 		/// <returns>Asynchronously returns the <see cref="Model"/> with all available properties</returns>
 		public async Task<Model> RetrieveModelDetailsAsync(string id)
 		{
-			string resultAsString = await HttpGetContent<JsonHelperRoot>($"{Url}/{id}");
+			string resultAsString = await HttpGetContentAsync<JsonHelperRoot>($"{Url}/{id}");
 			var model = JsonConvert.DeserializeObject<Model>(resultAsString);
 			return model;
 		}
@@ -39,7 +39,7 @@ namespace OpenAI_API.Models
 		/// <returns>Asynchronously returns the list of all <see cref="Model"/>s</returns>
 		public async Task<List<Model>> GetModelsAsync()
 		{
-			return (await HttpGet<JsonHelperRoot>()).data;
+			return (await HttpGetAsync<JsonHelperRoot>()).data;
 		}
 
 		/// <summary>

--- a/OpenAI_API/Moderation/ModerationEndpoint.cs
+++ b/OpenAI_API/Moderation/ModerationEndpoint.cs
@@ -45,7 +45,7 @@ namespace OpenAI_API.Moderation
 		/// <returns>Asynchronously returns the classification result</returns>
 		public async Task<ModerationResult> CallModerationAsync(ModerationRequest request)
 		{
-			return await HttpPost<ModerationResult>(postData: request);
+			return await HttpPostAsync<ModerationResult>(postData: request);
 		}
 	}
 }

--- a/OpenAI_Tests/AuthTests.cs
+++ b/OpenAI_Tests/AuthTests.cs
@@ -110,17 +110,17 @@ namespace OpenAI_Tests
 		public async Task TestBadKey()
 		{
 			var auth = new OpenAI_API.APIAuthentication("pk-testAA");
-			Assert.IsFalse(await auth.ValidateAPIKey());
+			Assert.IsFalse(await auth.ValidateAPIKeyAsync());
 
 			auth = new OpenAI_API.APIAuthentication(null);
-			Assert.IsFalse(await auth.ValidateAPIKey());
+			Assert.IsFalse(await auth.ValidateAPIKeyAsync());
 		}
 
 		[Test]
 		public async Task TestValidateGoodKey()
 		{
 			var auth = new OpenAI_API.APIAuthentication(Environment.GetEnvironmentVariable("TEST_OPENAI_SECRET_KEY"));
-			Assert.IsTrue(await auth.ValidateAPIKey());
+			Assert.IsTrue(await auth.ValidateAPIKeyAsync());
 		}
 
 	}

--- a/OpenAI_Tests/ChatEndpointTests.cs
+++ b/OpenAI_Tests/ChatEndpointTests.cs
@@ -97,12 +97,12 @@ namespace OpenAI_Tests
 			chat.AppendUserInput("Is this an animal? House");
 			chat.AppendExampleChatbotOutput("No");
 			chat.AppendUserInput("Is this an animal? Dog");
-			string res = chat.GetResponseFromChatbot().Result;
+			string res = chat.GetResponseFromChatbotAsync().Result;
 			Assert.NotNull(res);
 			Assert.IsNotEmpty(res);
 			Assert.AreEqual("Yes", res.Trim());
 			chat.AppendUserInput("Is this an animal? Chair");
-			res = chat.GetResponseFromChatbot().Result;
+			res = chat.GetResponseFromChatbotAsync().Result;
 			Assert.NotNull(res);
 			Assert.IsNotEmpty(res);
 			Assert.AreEqual("No", res.Trim());


### PR DESCRIPTION
Updates the project to use `Async` suffix for every method which returns a  `Task` or `Task<T>`. 

This is so we don't have ambiguity when to await something and when not.
Also if we want some synchronous operations we now have the option to do that.