### PR TITLE
Added HttpClient Injection

### DIFF
--- a/OpenAI_API/Chat/ChatEndpoint.cs
+++ b/OpenAI_API/Chat/ChatEndpoint.cs
@@ -30,6 +30,13 @@ namespace OpenAI_API.Chat
 		internal ChatEndpoint(OpenAIAPI api) : base(api) { }
 
 		/// <summary>
+		/// Constructor of the api endpoint.  Rather than instantiating this yourself, access it through an instance of <see cref="OpenAIAPI"/> as <see cref="OpenAIAPI.Completions"/>.
+		/// </summary>
+		/// <param name="httpClient"></param>
+		/// <param name="api"></param>
+		internal ChatEndpoint(HttpClient httpClient, OpenAIAPI api) : base(api) { }
+
+		/// <summary>
 		/// Creates an ongoing chat which can easily encapsulate the conversation.  This is the simplest way to use the Chat endpoint.
 		/// </summary>
 		/// <returns></returns>

--- a/OpenAI_API/Completions/CompletionEndpoint.cs
+++ b/OpenAI_API/Completions/CompletionEndpoint.cs
@@ -27,6 +27,13 @@ namespace OpenAI_API.Completions
 		/// <param name="api"></param>
 		internal CompletionEndpoint(OpenAIAPI api) : base(api) { }
 
+		/// <summary>
+		/// Constructor of the api endpoint.  Rather than instantiating this yourself, access it through an instance of <see cref="OpenAIAPI"/> as <see cref="OpenAIAPI.Completions"/>.
+		/// </summary>
+		/// <param name="httpClient"></param>
+		/// <param name="api"></param>
+		internal CompletionEndpoint(HttpClient httpClient, OpenAIAPI api) : base(httpClient, api) { }
+
 		#region Non-streaming
 
 		/// <summary>

--- a/OpenAI_API/Embedding/EmbeddingEndpoint.cs
+++ b/OpenAI_API/Embedding/EmbeddingEndpoint.cs
@@ -1,4 +1,5 @@
-﻿using OpenAI_API.Models;
+﻿using System.Net.Http;
+using OpenAI_API.Models;
 using System.Threading.Tasks;
 
 namespace OpenAI_API.Embedding
@@ -23,6 +24,13 @@ namespace OpenAI_API.Embedding
 		/// </summary>
 		/// <param name="api"></param>
 		internal EmbeddingEndpoint(OpenAIAPI api) : base(api) { }
+
+		/// <summary>
+		/// Constructor of the api endpoint.  Rather than instantiating this yourself, access it through an instance of <see cref="OpenAIAPI"/> as <see cref="OpenAIAPI.Embeddings"/>.
+		/// </summary>
+		/// <param name="httpClient"></param>
+		/// <param name="api"></param>
+		internal EmbeddingEndpoint(HttpClient httpClient, OpenAIAPI api) : base(httpClient, api) { }
 
 		/// <summary>
 		/// Ask the API to embedd text using the default embedding model <see cref="Model.AdaTextEmbedding"/>

--- a/OpenAI_API/EndpointBase.cs
+++ b/OpenAI_API/EndpointBase.cs
@@ -18,6 +18,8 @@ namespace OpenAI_API
 	{
 		private const string UserAgent = "okgodoit/dotnet_openai_api";
 
+		private HttpClient _httpClient;
+
 		/// <summary>
 		/// The internal reference to the API, mostly used for authentication
 		/// </summary>
@@ -30,6 +32,18 @@ namespace OpenAI_API
 		internal EndpointBase(OpenAIAPI api)
 		{
 			this._Api = api;
+		}
+
+		/// <summary>
+		/// Constructor of the api endpoint base, to be called from the contructor of any devived classes.
+		/// Rather than instantiating any endpoint yourself, access it through an instance of <see cref="OpenAIAPI"/>.
+		/// </summary>
+		/// <param name="httpClient"></param>
+		/// <param name="api"></param>
+		internal EndpointBase(HttpClient httpClient, OpenAIAPI api)
+		{
+			this._Api = api;
+			this._httpClient = httpClient;
 		}
 
 		/// <summary>
@@ -67,15 +81,17 @@ namespace OpenAI_API
 				_Api.SharedHttpClient.
 			}
 			*/
-
-			HttpClient client = new HttpClient();
-			client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _Api.Auth.ApiKey);
+			
+			_httpClient ??= new HttpClient();
+			
+			_httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _Api.Auth.ApiKey);
 			// Further authentication-header used for Azure openAI service
-			client.DefaultRequestHeaders.Add("api-key", _Api.Auth.ApiKey);
-			client.DefaultRequestHeaders.Add("User-Agent", UserAgent);
-			if (!string.IsNullOrEmpty(_Api.Auth.OpenAIOrganization)) client.DefaultRequestHeaders.Add("OpenAI-Organization", _Api.Auth.OpenAIOrganization);
+			_httpClient.DefaultRequestHeaders.Add("api-key", _Api.Auth.ApiKey);
+			_httpClient.DefaultRequestHeaders.Add("User-Agent", UserAgent);
+			if (!string.IsNullOrEmpty(_Api.Auth.OpenAIOrganization)) 
+				_httpClient.DefaultRequestHeaders.Add("OpenAI-Organization", _Api.Auth.OpenAIOrganization);
 
-			return client;
+			return _httpClient;
 		}
 
 		/// <summary>

--- a/OpenAI_API/Files/FilesEndpoint.cs
+++ b/OpenAI_API/Files/FilesEndpoint.cs
@@ -18,6 +18,13 @@ namespace OpenAI_API.Files
 		internal FilesEndpoint(OpenAIAPI api) : base(api) { }
 
 		/// <summary>
+		/// Constructor of the api endpoint.  Rather than instantiating this yourself, access it through an instance of <see cref="OpenAIAPI"/> as <see cref="OpenAIAPI.Files"/>.
+		/// </summary>
+		/// <param name="httpClient"></param>
+		/// <param name="api"></param>
+		internal FilesEndpoint(HttpClient httpClient, OpenAIAPI api) : base(httpClient, api) { }
+
+		/// <summary>
 		/// The name of the endpoint, which is the final path segment in the API URL.  For example, "files".
 		/// </summary>
 		protected override string Endpoint { get { return "files"; } }

--- a/OpenAI_API/Images/ImageGenerationEndpoint.cs
+++ b/OpenAI_API/Images/ImageGenerationEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using OpenAI_API.Models;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -21,6 +22,13 @@ namespace OpenAI_API.Images
 		/// </summary>
 		/// <param name="api"></param>
 		internal ImageGenerationEndpoint(OpenAIAPI api) : base(api) { }
+
+		/// <summary>
+		/// Constructor of the api endpoint.  Rather than instantiating this yourself, access it through an instance of <see cref="OpenAIAPI"/> as <see cref="OpenAIAPI.ImageGenerations"/>.
+		/// </summary>
+		/// <param name="httpClient"></param>
+		/// <param name="api"></param>
+		internal ImageGenerationEndpoint(HttpClient httpClient, OpenAIAPI api)  : base(httpClient, api) { }
 
 		/// <summary>
 		/// Ask the API to Creates an image given a prompt.

--- a/OpenAI_API/Model/ModelsEndpoint.cs
+++ b/OpenAI_API/Model/ModelsEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace OpenAI_API.Models
@@ -20,6 +21,13 @@ namespace OpenAI_API.Models
 		/// </summary>
 		/// <param name="api"></param>
 		internal ModelsEndpoint(OpenAIAPI api) : base(api) { }
+
+		/// <summary>
+		/// Constructor of the api endpoint.  Rather than instantiating this yourself, access it through an instance of <see cref="OpenAIAPI"/> as <see cref="OpenAIAPI.Models"/>.
+		/// </summary>
+		/// <param name="httpClient"></param>
+		/// <param name="api"></param>
+		internal ModelsEndpoint(HttpClient httpClient, OpenAIAPI api) : base(httpClient, api) { }
 
 		/// <summary>
 		/// Get details about a particular Model from the API, specifically properties such as <see cref="Model.OwnedBy"/> and permissions.

--- a/OpenAI_API/Moderation/ModerationEndpoint.cs
+++ b/OpenAI_API/Moderation/ModerationEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using OpenAI_API.Models;
 using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -26,6 +27,13 @@ namespace OpenAI_API.Moderation
 		/// </summary>
 		/// <param name="api"></param>
 		internal ModerationEndpoint(OpenAIAPI api) : base(api) { }
+
+		/// <summary>
+		/// Constructor of the api endpoint. Rather than instantiating this yourself, access it through an instance of <see cref="OpenAIAPI"/> as <see cref="OpenAIAPI.Moderation"/>.
+		/// </summary>
+		/// <param name="httpClient"></param>
+		/// <param name="api"></param>
+		internal ModerationEndpoint(HttpClient httpClient, OpenAIAPI api) : base(httpClient, api) { }
 
 		/// <summary>
 		/// Ask the API to classify the text using the default model.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Console.WriteLine(result);
  * [Files API](#files-for-fine-tuning)
  * [Image APIs (DALL-E)](#images)
  * [Azure](#azure)
+ * [Customize the HTTP Client](#customize-the-http-client)
  * [Additonal Documentation](#documentation)
  * [License](#license)
 
@@ -276,6 +277,29 @@ OpenAIAPI api = OpenAIAPI.ForAzure("YourResourceName", "deploymentId", "api-key"
 
 You may then use the `api` object like normal.  You may also specify the `APIAuthentication` is any of the other ways listed in the [Authentication](#authentication) section above.  Currently this library only supports the api-key flow, not the AD-Flow.
 
+## Customize the HTTP Client
+
+You can customize the HttpClient used in the wrapper by specifing it in the constructor or in the `ForAzure` static method.
+```csharp
+builder.Services.AddHttpClient<OpenAiBusinessService>()
+    .SetHandlerLifetime(TimeSpan.FromMinutes(30))
+    .AddPolicyHandler(RetryPolicy.GetTooManyRequestRetryPolicy())
+```
+And then in your class 
+```csharp
+public class OpenAiBusinessService
+{
+    private readonly OpenAIAPI _azureOpenAiApiWrapper;
+    private readonly OpenAIAPI _openAiWrapper;
+
+    public OpenAiBusinessService(HttpClient httpClient)
+    {
+        _azureOpenAiApiWrapper = OpenAIAPI.ForAzure("resource", "deploymentId", "apiKey");
+        _openAiWrapper = new OpenAIAPI(httpClient, new APIAuthentication("apiKey"));
+
+    }
+}
+```
 ## Documentation
 
 Every single class, method, and property has extensive XML documentation, so it should show up automatically in IntelliSense.  That combined with the official OpenAI documentation should be enough to get started.  Feel free to open an issue here if you have any questions.  Better documentation may come later.


### PR DESCRIPTION
I've added some constructor to be able to inject the HttpClient into the OpenAi class.
This allow to customize the HttpClient further such as adding a retry policy, or adding delegating handler to the HttpClient.
I also updated the readme file to show how we can use it in a simple case.