### PR TITLE
Allow an HttpClientFactory to be assigned to OpenAIAPI

### DIFF
--- a/OpenAI_API/EndpointBase.cs
+++ b/OpenAI_API/EndpointBase.cs
@@ -59,16 +59,18 @@ namespace OpenAI_API
 			{
 				throw new AuthenticationException("You must provide API authentication.  Please refer to https://github.com/OkGoDoIt/OpenAI-API-dotnet#authentication for details.");
 			}
-
-			/*
-			if (_Api.SharedHttpClient==null)
+	
+			HttpClient client;
+			var clientFactory = _Api.HttpClientFactory;
+			if (clientFactory != null)
 			{
-				_Api.SharedHttpClient = new HttpClient();
-				_Api.SharedHttpClient.
+				client = clientFactory.CreateClient();
 			}
-			*/
+			else
+			{
+				client = new HttpClient();
+			}
 
-			HttpClient client = new HttpClient();
 			client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _Api.Auth.ApiKey);
 			// Further authentication-header used for Azure openAI service
 			client.DefaultRequestHeaders.Add("api-key", _Api.Auth.ApiKey);

--- a/OpenAI_API/OpenAIAPI.cs
+++ b/OpenAI_API/OpenAIAPI.cs
@@ -5,7 +5,7 @@ using OpenAI_API.Files;
 using OpenAI_API.Images;
 using OpenAI_API.Models;
 using OpenAI_API.Moderation;
-using System.Xml.Linq;
+using System.Net.Http;
 
 namespace OpenAI_API
 {
@@ -30,6 +30,11 @@ namespace OpenAI_API
 		/// The API authentication information to use for API calls
 		/// </summary>
 		public APIAuthentication Auth { get; set; }
+
+		/// <summary>
+		/// Optionally provide an IHttpClientFactory to create the client to send requests.
+		/// </summary>
+		public IHttpClientFactory HttpClientFactory { get; set; }
 
 		/// <summary>
 		/// Creates a new entry point to the OpenAPI API, handling auth and allowing access to the various API endpoints
@@ -96,6 +101,5 @@ namespace OpenAI_API
 		/// The API lets you do operations with images. You can Given a prompt and/or an input image, the model will generate a new image.
 		/// </summary>
 		public ImageGenerationEndpoint ImageGenerations { get; }
-
 	}
 }

--- a/OpenAI_API/OpenAI_API.csproj
+++ b/OpenAI_API/OpenAI_API.csproj
@@ -43,9 +43,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="OpenAI_Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="1.1.1" />
 	</ItemGroup>
 
 </Project>

--- a/OpenAI_Tests/HttpClientResolutionTests.cs
+++ b/OpenAI_Tests/HttpClientResolutionTests.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using OpenAI_API;
+using System;
+using System.Linq;
+using System.Net.Http;
+
+namespace OpenAI_Tests
+{
+    public class HttpClientResolutionTests
+    {
+        [Test]
+        public void GetHttpClient_NoFactory()
+        {
+            var api = new OpenAIAPI(new APIAuthentication("fake-key"));
+            var endpoint = new TestEndpoint(api);
+
+            var client = endpoint.GetHttpClient();
+            Assert.IsNotNull(client);
+        }
+
+        [Test]
+        public void GetHttpClient_WithFactory()
+        {
+            var expectedClient1 = new HttpClient();
+            var mockedFactory1 = Mock.Of<IHttpClientFactory>(f => f.CreateClient(Options.DefaultName) == expectedClient1);
+
+            var expectedClient2 = new HttpClient();
+            var mockedFactory2 = Mock.Of<IHttpClientFactory>(f => f.CreateClient(Options.DefaultName) == expectedClient2);
+
+            var api = new OpenAIAPI(new APIAuthentication("fake-key"));
+            var endpoint = new TestEndpoint(api);
+
+            api.HttpClientFactory = mockedFactory1;
+            var actualClient1 = endpoint.GetHttpClient();
+
+            api.HttpClientFactory = mockedFactory2;
+            var actualClient2 = endpoint.GetHttpClient();
+
+            Assert.AreSame(expectedClient1, actualClient1);
+            Assert.AreSame(expectedClient2, actualClient2);
+
+            api.HttpClientFactory = null;
+            var actualClient3 = endpoint.GetHttpClient();
+
+            Assert.NotNull(actualClient3);
+            Assert.AreNotSame(expectedClient1, actualClient3);
+            Assert.AreNotSame(expectedClient2, actualClient3);
+        }
+
+        private class TestEndpoint : EndpointBase
+        {
+            public TestEndpoint(OpenAIAPI api) : base(api)
+            {
+            }
+
+            protected override string Endpoint => throw new System.NotSupportedException();
+
+            public HttpClient GetHttpClient()
+            {
+                return base.GetClient();
+            }
+        }
+    }
+}

--- a/OpenAI_Tests/OpenAI_Tests.csproj
+++ b/OpenAI_Tests/OpenAI_Tests.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="nunit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />


### PR DESCRIPTION
This change aims to enable consumers to use `IHttpClientFactory` and apply resiliency best practices described in [this document](https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/use-httpclientfactory-to-implement-resilient-http-requests) without a breaking change. Consumers can now implement non-functional requirements such as:

- Configuring retry policies to the outgoing HTTP requests.
- Logging and telemetry instrumentation to outgoing HTTP calls.
- Mocking the HTTP responses for integration testing scenarios

Implementation wise, I opted not to modify the constructor as it takes an optional parameter. Adding another optional parameter is a breaking change, and mixing optional parameters with overloaded constructors is not generally recommended. Effectively seeking to minimize change.

Package wise, the dependency on `Microsoft.Extensions.Http` is no longer private. 

I used `Moq` in the unit tests to mock an HTTP Client and ensure the right client is used in the right place. 

Related issues that could be addressed with this change (or at least allow a workaround):
#102
#100 
#91 
#41 
#28 
