### PR TITLE
Use interface instead of implementation in Endpoint properties

### DIFF
--- a/OpenAI_API/IOpenAIAPI.cs
+++ b/OpenAI_API/IOpenAIAPI.cs
@@ -1,7 +1,10 @@
+using OpenAI_API.Chat;
 using OpenAI_API.Completions;
 using OpenAI_API.Embedding;
 using OpenAI_API.Files;
+using OpenAI_API.Images;
 using OpenAI_API.Models;
+using OpenAI_API.Moderation;
 
 namespace OpenAI_API
 {
@@ -28,23 +31,38 @@ namespace OpenAI_API
         APIAuthentication Auth { get; set; }
 
         /// <summary>
+        /// Text generation in the form of chat messages. This interacts with the ChatGPT API.
+        /// </summary>
+        IChatEndpoint Chat { get; }
+
+        /// <summary>
+        /// Classify text against the OpenAI Content Policy.
+        /// </summary>
+        IModerationEndpoint Moderation { get; }
+
+        /// <summary>
         /// Text generation is the core function of the API. You give the API a prompt, and it generates a completion. The way you “program” the API to do a task is by simply describing the task in plain english or providing a few written examples. This simple approach works for a wide range of use cases, including summarization, translation, grammar correction, question answering, chatbots, composing emails, and much more (see the prompt library for inspiration).
         /// </summary>
-        CompletionEndpoint Completions { get; }
+        ICompletionEndpoint Completions { get; }
 
         /// <summary>
         /// The API lets you transform text into a vector (list) of floating point numbers. The distance between two vectors measures their relatedness. Small distances suggest high relatedness and large distances suggest low relatedness.
         /// </summary>
-        EmbeddingEndpoint Embeddings { get; }
+        IEmbeddingEndpoint Embeddings { get; }
 
         /// <summary>
         /// The API endpoint for querying available Engines/models
         /// </summary>
-        ModelsEndpoint Models { get; }
+        IModelsEndpoint Models { get; }
 
         /// <summary>
         /// The API lets you do operations with files. You can upload, delete or retrieve files. Files can be used for fine-tuning, search, etc.
         /// </summary>
-        FilesEndpoint Files { get; }
+        IFilesEndpoint Files { get; }
+
+        /// <summary>
+        /// The API lets you do operations with images. You can Given a prompt and/or an input image, the model will generate a new image.
+        /// </summary>
+        IImageGenerationEndpoint ImageGenerations { get; }
     }
 }

--- a/OpenAI_API/OpenAIAPI.cs
+++ b/OpenAI_API/OpenAIAPI.cs
@@ -65,37 +65,37 @@ namespace OpenAI_API
 		/// <summary>
 		/// Text generation is the core function of the API. You give the API a prompt, and it generates a completion. The way you “program” the API to do a task is by simply describing the task in plain english or providing a few written examples. This simple approach works for a wide range of use cases, including summarization, translation, grammar correction, question answering, chatbots, composing emails, and much more (see the prompt library for inspiration).
 		/// </summary>
-		public CompletionEndpoint Completions { get; }
+		public ICompletionEndpoint Completions { get; }
 
 		/// <summary>
 		/// The API lets you transform text into a vector (list) of floating point numbers. The distance between two vectors measures their relatedness. Small distances suggest high relatedness and large distances suggest low relatedness.
 		/// </summary>
-		public EmbeddingEndpoint Embeddings { get; }
+		public IEmbeddingEndpoint Embeddings { get; }
 
 		/// <summary>
 		/// Text generation in the form of chat messages. This interacts with the ChatGPT API.
 		/// </summary>
-		public ChatEndpoint Chat { get; }
+		public IChatEndpoint Chat { get; }
 
 		/// <summary>
 		/// Classify text against the OpenAI Content Policy.
 		/// </summary>
-		public ModerationEndpoint Moderation { get; }
+		public IModerationEndpoint Moderation { get; }
 
 		/// <summary>
 		/// The API endpoint for querying available Engines/models
 		/// </summary>
-		public ModelsEndpoint Models { get; }
+		public IModelsEndpoint Models { get; }
 
 		/// <summary>
 		/// The API lets you do operations with files. You can upload, delete or retrieve files. Files can be used for fine-tuning, search, etc.
 		/// </summary>
-		public FilesEndpoint Files { get; }
+		public IFilesEndpoint Files { get; }
 
 		/// <summary>
 		/// The API lets you do operations with images. You can Given a prompt and/or an input image, the model will generate a new image.
 		/// </summary>
-		public ImageGenerationEndpoint ImageGenerations { get; }
+		public IImageGenerationEndpoint ImageGenerations { get; }
 
 	}
 }


### PR DESCRIPTION
The problem is described in #68. 

> The endpoint properties should be defined as interfaces instead of classes so that they are also suitable for Moq tests. Additionally, the IChatEndpoint interface should be added as a property.

This PR replaces #69 as it would otherwise create a conflict between the changes.

Note that this is a breaking change. 