### PR TITLE
Updated Readme to reference api.ImageGenerations

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,9 +277,9 @@ The DALL-E Image Generation API is accessed via `OpenAIAPI.ImageGenerations`:
 async Task<ImageResult> CreateImageAsync(ImageGenerationRequest request);
 
 // for example
-var result = await api.Images.CreateImageAsync(new ImageGenerationRequest("A drawing of a computer writing a test", 1, ImageSize._512));
+var result = await api.ImageGenerations.CreateImageAsync(new ImageGenerationRequest("A drawing of a computer writing a test", 1, ImageSize._512));
 // or
-var result = await api.Images.CreateImageAsync("A drawing of a computer writing a test");
+var result = await api.ImageGenerations.CreateImageAsync("A drawing of a computer writing a test");
 
 Console.WriteLine(result.Data[0].Url);
 ```


### PR DESCRIPTION
It seems that Images has been renamed to ImageGenerations in #65 so the Readme file should also be updated. 