### PR TITLE
Re-targeted framework to .NET 6.0 for tests.

### DIFF
--- a/OpenAI_API.sln.DotSettings
+++ b/OpenAI_API.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=logprobs/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OpenAI_API/Chat/ChatRequest.cs
+++ b/OpenAI_API/Chat/ChatRequest.cs
@@ -1,8 +1,7 @@
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using OpenAI_API.Completions;
 
 namespace OpenAI_API.Chat
 {
@@ -16,7 +15,7 @@ namespace OpenAI_API.Chat
 		/// The model to use for this request
 		/// </summary>
 		[JsonProperty("model")]
-		public string Model { get; set; } = OpenAI_API.Models.Model.ChatGPTTurbo;
+		public string Model { get; set; } = Models.Model.ChatGPTTurbo;
 
 		/// <summary>
 		/// The messages to send with this Chat Request
@@ -46,7 +45,7 @@ namespace OpenAI_API.Chat
 		/// Specifies where the results should stream and be returned at one time.  Do not set this yourself, use the appropriate methods on <see cref="CompletionEndpoint"/> instead.
 		/// </summary>
 		[JsonProperty("stream")]
-		public bool Stream { get; internal set; } = false;
+		public bool Stream { get; internal set; }
 
 		/// <summary>
 		/// This is only used for serializing the request into JSON, do not use it directly.
@@ -77,7 +76,7 @@ namespace OpenAI_API.Chat
 		[JsonIgnore]
 		public string StopSequence
 		{
-			get => MultipleStopSequences?.FirstOrDefault() ?? null;
+			get => MultipleStopSequences?.FirstOrDefault();
 			set
 			{
 				if (value != null)

--- a/OpenAI_API/Completions/CompletionResult.cs
+++ b/OpenAI_API/Completions/CompletionResult.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using OpenAI_API.Embedding;
 using System.Collections.Generic;
 
 namespace OpenAI_API.Completions
@@ -89,18 +88,32 @@ namespace OpenAI_API.Completions
 		}
 	}
 
-
+	/// <summary>
+	/// Represents the logprobs property of a completion choice
+	/// </summary>
 	public class Logprobs
 	{
+		/// <summary>
+		/// The tokens that were used to generate the completion
+		/// </summary>
 		[JsonProperty("tokens")]
 		public List<string> Tokens { get; set; }
 
+		/// <summary>
+		/// The log probabilities of each token
+		/// </summary>
 		[JsonProperty("token_logprobs")]
 		public List<double?> TokenLogprobs { get; set; }
 
+		/// <summary>
+		/// The top log probabilities for each token
+		/// </summary>
 		[JsonProperty("top_logprobs")]
 		public IList<IDictionary<string, double>> TopLogprobs { get; set; }
 
+		/// <summary>
+		/// The token ids of the tokens
+		/// </summary>
 		[JsonProperty("text_offset")]
 		public List<int> TextOffsets { get; set; }
 	}

--- a/OpenAI_API/Files/IFilesEndpoint.cs
+++ b/OpenAI_API/Files/IFilesEndpoint.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace OpenAI_API.Files
@@ -40,7 +41,7 @@ namespace OpenAI_API.Files
         /// Upload a file that contains document(s) to be used across various endpoints/features. Currently, the size of all the files uploaded by one organization can be up to 1 GB. Please contact OpenAI if you need to increase the storage limit
         /// </summary>
         /// <param name="filePath">The name of the file to use for this request</param>
-        /// <param name="purpose">The intendend purpose of the uploaded documents. Use "fine-tune" for Fine-tuning. This allows us to validate the format of the uploaded file.</param>
+        /// <param name="purpose">The intended purpose of the uploaded documents. Use "fine-tune" for Fine-tuning. This allows us to validate the format of the uploaded file.</param>
         Task<File> UploadFileAsync(string filePath, string purpose = "fine-tune");
     }
 }

--- a/OpenAI_API/Model/Model.cs
+++ b/OpenAI_API/Model/Model.cs
@@ -230,6 +230,9 @@ namespace OpenAI_API.Models
 		[JsonProperty("allow_search_indices")]
 		public bool AllowSearchIndices { get; set; }
 
+		/// <summary>
+		/// Does the model allow viewing?
+		/// </summary>
 		[JsonProperty("allow_view")]
 		public bool AllowView { get; set; }
 
@@ -252,6 +255,9 @@ namespace OpenAI_API.Models
 		[JsonProperty("group")]
 		public string Group { get; set; }
 
+		/// <summary>
+		/// Is the model allowed to be used for blocking? May not be implemented yet.
+		/// </summary>
 		[JsonProperty("is_blocking")]
 		public bool IsBlocking { get; set; }
 	}

--- a/OpenAI_API/OpenAI_API.csproj
+++ b/OpenAI_API/OpenAI_API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
 		<LangVersion>8.0</LangVersion>
 		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 		<Authors>OkGoDoIt (Roger Pincombe)</Authors>

--- a/OpenAI_Tests/OpenAI_Tests.csproj
+++ b/OpenAI_Tests/OpenAI_Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Re-targeted framework to .NET 6.0 for tests.
Re-targeted framework to NET Standard 2.1 for library.
Fixed XML warnings and typos.
Removed superfluous references.
Added required references.
Added DotSettings file to keep track of a dictionary of allowed terms for ReSharper.