### PR TITLE
add new gpt-3.5-turbo-instruct model

### DIFF
--- a/OpenAI_API/Model/Model.cs
+++ b/OpenAI_API/Model/Model.cs
@@ -128,6 +128,17 @@ namespace OpenAI_API.Models
 		/// </summary>
 		public static Model DavinciCode => new Model("code-davinci-002") { OwnedBy = "openai" };
 
+        /// <summary>
+        /// Similar capabilities as text-davinci-003 but compatible with legacy Completions endpoint and not Chat Completions.
+        /// </summary>
+        public static Model GPTTurboInstruct => new Model("gpt-3.5-turbo-instruct") { OwnedBy = "openai" };
+
+        /// <summary>
+		/// Snapshot of gpt-3.5-turbo-instruct from September 14th 2023. Unlike gpt-3.5-turbo-instruct, this model will not receive updates, and will be deprecated 3 months after a new version is released.
+        /// Similar capabilities as text-davinci-003 but compatible with legacy Completions endpoint and not Chat Completions.
+        /// </summary>
+        public static Model GPTTurboInstruct0914 => new Model("gpt-3.5-turbo-instruct-0914") { OwnedBy = "openai" };
+
 		/// <summary>
 		/// OpenAI offers one second-generation embedding model for use with the embeddings API endpoint.
 		/// </summary>

--- a/OpenAI_API/Model/Model.cs
+++ b/OpenAI_API/Model/Model.cs
@@ -118,6 +118,11 @@ namespace OpenAI_API.Models
 		/// </summary>
 		public static Model DavinciText => new Model("text-davinci-003") { OwnedBy = "openai" };
 
+        /// <summary>
+        /// Similar capabilities to text-davinci-003 but trained with supervised fine-tuning instead of reinforcement learning
+        /// </summary>
+        public static Model DavinciText002 => new Model("text-davinci-002") { OwnedBy = "openai" };
+
 		/// <summary>
 		/// Almost as capable as Davinci Codex, but slightly faster. This speed advantage may make it preferable for real-time applications.
 		/// </summary>


### PR DESCRIPTION
gpt-3.5-turbo-instruct model is a new completion model that will replace legacy InstructGPT completion models such as text-davinci-003 or text-curie-001
they will be deprecated as of jan 2024. reference: [https://platform.openai.com/docs/deprecations](https://platform.openai.com/docs/deprecations)

